### PR TITLE
Set up compute graph basics

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,6 +31,8 @@ includes:
     taskfile: dev-task/easyrsa.yml
   lib-collection:
     taskfile: lib-collection
+  lib-compute:
+    taskfile: lib-compute
   lib-concurrency:
     taskfile: lib-concurrency
   lib-error:
@@ -200,6 +202,7 @@ tasks:
       - dev-prettier:link-build-dir
       - dev-tsconfig:link-build-dir
       - lib-collection:link-build-dir
+      - lib-compute:link-build-dir
       - lib-concurrency:link-build-dir
       - lib-error:link-build-dir
       - lib-hex-ts:link-build-dir

--- a/dev-eslint/index.json
+++ b/dev-eslint/index.json
@@ -143,6 +143,10 @@
         }
       }
     ],
+    "@typescript-eslint/no-empty-function": [
+      "error",
+      { "allow": ["private-constructors"] }
+    ],
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-loop-func": "error",
     "@typescript-eslint/no-unnecessary-condition": [
@@ -159,6 +163,7 @@
     "@typescript-eslint/no-use-before-define": [
       "warn",
       {
+        "classes": false,
         "functions": false,
         "variables": false
       }

--- a/dev-pnpm-test/index.ts
+++ b/dev-pnpm-test/index.ts
@@ -1,6 +1,7 @@
 import type * as test from '@intertwine/lib-test'
 
 export const all: test.TestCollection = () => [
+  import('@intertwine/lib-compute/index.test.ts'),
   import('@intertwine/lib-error/index.test.ts'),
   import('@intertwine/lib-payload/index.test.ts'),
   import('@intertwine/lib-test/hex.test.ts'),

--- a/dev-pnpm-test/package.json
+++ b/dev-pnpm-test/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@intertwine/dev-prettier": "workspace:*",
     "@intertwine/dev-tsconfig": "workspace:*",
+    "@intertwine/lib-compute": "workspace:*",
     "@intertwine/lib-error": "workspace:*",
     "@intertwine/lib-hex": "workspace:*",
     "@intertwine/lib-payload": "workspace:*",

--- a/dev-task/pnpm.yml
+++ b/dev-task/pnpm.yml
@@ -135,7 +135,7 @@ tasks:
         WATCH: true
         RESTART: false
         MODE: type-script
-        COMMAND: tsc --build --verbose
+        COMMAND: tsc --build
 
   test:
     aliases:

--- a/lib-compute/Taskfile.yml
+++ b/lib-compute/Taskfile.yml
@@ -1,0 +1,10 @@
+run: when_changed
+tasks:
+  link-build-dir:
+    cmd:
+      task: :tmpfs:link-package-build-dir
+      vars:
+        NAME: '{{.NAME}}'
+vars:
+  NAME: lib-compute
+version: '3'

--- a/lib-compute/index.test.ts
+++ b/lib-compute/index.test.ts
@@ -1,0 +1,367 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+import * as compute from '@/index.ts'
+import * as test from '@intertwine/lib-test'
+
+export const url = import.meta.url
+
+export const tests = {
+  async ['handler, multiple'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const x = compute.state('x')
+    const y = compute.state('y')
+    const callback = compute.handler(
+      (event: number, valueX, valueY) => `${event},${valueX},${valueY}`,
+      x,
+      y,
+    )
+    test.assertEquals(await callback(1), '1,x,y')
+    test.assertEquals(await callback(2), '2,x,y')
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'a')
+      await compute.set(ctx, y, 'b')
+    })
+    test.assertEquals(await callback(3), '3,a,b')
+  },
+
+  async ['pure, value'](): Promise<void> {
+    const x = compute.pure('x')
+    test.assertEquals(await compute.value(x), 'x')
+  },
+
+  async ['map, value'](): Promise<void> {
+    const parent = compute.pure(0)
+    const [callback, callbackHistory] = test.repeatMockWithHistory(
+      1,
+      (parentValue: number) => parentValue + 1,
+    )
+    const child = compute.map(callback, parent)
+    test.assertDeepEquals(callbackHistory, [])
+    test.assertEquals(await compute.value(parent), 0)
+    test.assertEquals(await compute.value(child), 1)
+    test.assertDeepEquals(callbackHistory, [[0]])
+    test.assertEquals(await compute.value(child), 1)
+    test.assertDeepEquals(callbackHistory, [[0]])
+  },
+
+  async ['map, multiple'](): Promise<void> {
+    const x = compute.pure(2)
+    const y = compute.pure(3)
+    const [callback, callbackHistory] = test.repeatMockWithHistory(
+      1,
+      (parentX: number, parentY: number) => parentX * parentY,
+    )
+    const child = compute.map(callback, x, y)
+    test.assertDeepEquals(callbackHistory, [])
+    test.assertEquals(await compute.value(x), 2)
+    test.assertEquals(await compute.value(y), 3)
+    test.assertEquals(await compute.value(child), 6)
+    test.assertDeepEquals(callbackHistory, [[2, 3]])
+    test.assertEquals(await compute.value(child), 6)
+    test.assertDeepEquals(callbackHistory, [[2, 3]])
+  },
+
+  async ['map, shortcut object'](): Promise<void> {
+    const parent = compute.pure({ x: 0 })
+    const child = parent.x
+    test.assertDeepEquals(await compute.value(parent), { x: 0 })
+    test.assertEquals(await compute.value(child), 0)
+  },
+
+  async ['map, shortcut tuple'](): Promise<void> {
+    const parent = compute.pure([0] as [number])
+    const child = parent[0]
+    test.assertDeepEquals(await compute.value(parent), [0])
+    test.assertEquals(await compute.value(child), 0)
+  },
+
+  async ['state, value'](): Promise<void> {
+    const x = compute.state('x')
+    test.assertEquals(await compute.value(x), 'x')
+  },
+
+  async ['state, set'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const x = compute.state('x')
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'a')
+    })
+    test.assertEquals(await compute.value(x), 'a')
+  },
+
+  async ['state, nested set'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const x = compute.state('x')
+    const y = compute.state('y')
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'a')
+      await compute.txn(ctx, async () => {
+        await compute.set(ctx, y, 'b')
+      })
+    })
+    test.assertEquals(await compute.value(x), 'a')
+    test.assertEquals(await compute.value(y), 'b')
+  },
+
+  async ['state, rollback'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const x = compute.state('x')
+    const error = await test.assertThrowsAsync(async () =>
+      compute.txn(ctx, async () => {
+        await compute.set(ctx, x, 'y')
+        throw new Error('rollback')
+      }),
+    )
+    test.assertInstanceOf(error, Error)
+    test.assertEquals(error.message, 'rollback')
+    test.assertEquals(await compute.value(x), 'x')
+  },
+
+  async ['state, nested rollback'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const x = compute.state('x')
+    const y = compute.state('y')
+    const error = await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'a')
+      return test.assertThrowsAsync(async () =>
+        compute.txn(ctx, async () => {
+          await compute.set(ctx, y, 'b')
+          throw new Error('rollback')
+        }),
+      )
+    })
+    test.assertInstanceOf(error, Error)
+    test.assertEquals(error.message, 'rollback')
+    test.assertEquals(await compute.value(x), 'a')
+    test.assertEquals(await compute.value(y), 'y')
+  },
+
+  async ['derived, set simple'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const parent = compute.state({ x: 'y' })
+    const [callback, callbackHistory] = test.repeatMockWithHistory(
+      1,
+      (parentValue: { readonly x: string }) => parentValue.x,
+    )
+    const child = compute.derived(
+      callback,
+      async (newValue, parentValue) => {
+        await compute.set(ctx, parent, { ...parentValue, x: newValue })
+      },
+      parent,
+    )
+    test.assertDeepEquals(callbackHistory, [])
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, child, 'z')
+    })
+    test.assertDeepEquals(callbackHistory, [])
+    test.assertDeepEquals(await compute.value(parent), { x: 'z' })
+    test.assertEquals(await compute.value(child), 'z')
+    test.assertDeepEquals(callbackHistory, [[{ x: 'z' }]])
+    test.assertEquals(await compute.value(child), 'z')
+    test.assertDeepEquals(callbackHistory, [[{ x: 'z' }]])
+  },
+
+  async ['derived, set multiple'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const x = compute.state({ x: 'x' })
+    const y = compute.state({ y: 'y' })
+    const [callback, callbackHistory] = test.repeatMockWithHistory(
+      1,
+      (
+        parentX: { readonly x: string },
+        parentY: { readonly y: string },
+      ) => ({ ...parentX, ...parentY }),
+    )
+    const child = compute.derived(
+      callback,
+      async (newValue, parentX, parentY) => {
+        await compute.set(ctx, x, { ...parentX, x: newValue.x })
+        await compute.set(ctx, y, { ...parentY, y: newValue.y })
+      },
+      x,
+      y,
+    )
+    test.assertDeepEquals(callbackHistory, [])
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, child, { x: 'a', y: 'b' })
+    })
+    test.assertDeepEquals(callbackHistory, [])
+    test.assertDeepEquals(await compute.value(x), { x: 'a' })
+    test.assertDeepEquals(await compute.value(y), { y: 'b' })
+    test.assertDeepEquals(await compute.value(child), { x: 'a', y: 'b' })
+    test.assertDeepEquals(callbackHistory, [[{ x: 'a' }, { y: 'b' }]])
+    test.assertDeepEquals(await compute.value(child), { x: 'a', y: 'b' })
+    test.assertDeepEquals(callbackHistory, [[{ x: 'a' }, { y: 'b' }]])
+  },
+
+  async ['derived, set shortcut object'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const parent = compute.state({ x: 'y' })
+    const child = parent.x
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, child, 'z')
+    })
+    test.assertDeepEquals(await compute.value(parent), { x: 'z' })
+    test.assertEquals(await compute.value(child), 'z')
+  },
+
+  async ['derived, set shortcut tuple'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const parent = compute.state(['y'] as [string])
+    const child = parent[0]
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, child, 'z')
+    })
+    test.assertDeepEquals(await compute.value(parent), ['z'])
+    test.assertEquals(await compute.value(child), 'z')
+  },
+
+  async ['effect, pure'](): Promise<void> {
+    const x = compute.pure('x')
+    const [callback, callbackHistory] = test.repeatMockWithHistory(
+      1,
+      (_value: string) => {},
+    )
+    await compute.effect(callback, x)
+    test.assertDeepEquals(callbackHistory, [['x']])
+    test.assertEquals(await compute.value(x), 'x')
+  },
+
+  async ['effect, state change simple'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const x = compute.state('x')
+    const [callback, callbackHistory] = test.repeatMockWithHistory(
+      2,
+      (_value: string) => {},
+    )
+    await compute.effect(callback, x)
+    test.assertDeepEquals(callbackHistory, [['x']])
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'a')
+    })
+    test.assertDeepEquals(callbackHistory, [['x'], ['a']])
+    test.assertEquals(await compute.value(x), 'a')
+  },
+
+  async ['effect, state change multiple'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+    const x = compute.state('x')
+    const y = compute.state('y')
+    const [callback, callbackHistory] = test.repeatMockWithHistory(
+      2,
+      (_valueX: string, _valueY: string) => {},
+    )
+    await compute.effect(callback, x, y)
+    test.assertDeepEquals(callbackHistory, [['x', 'y']])
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'a')
+      await compute.set(ctx, y, 'b')
+    })
+    test.assertDeepEquals(callbackHistory, [
+      ['x', 'y'],
+      ['a', 'b'],
+    ])
+    test.assertEquals(await compute.value(x), 'a')
+    test.assertEquals(await compute.value(y), 'b')
+  },
+
+  async ['effect, partial graph update'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+
+    const x = compute.state('x')
+    const [x2Callback, x2CallbackHistory] = test.repeatMockWithHistory(
+      2,
+      (valueY: string) => `${valueY}/${valueY}`,
+    )
+    const x2 = compute.map(x2Callback, x)
+
+    const y = compute.state('y')
+    const [y2Callback, y2CallbackHistory] = test.repeatMockWithHistory(
+      1,
+      (valueY: string) => `${valueY}?${valueY}`,
+    )
+    const y2 = compute.map(y2Callback, y)
+
+    const [effectCallback, effectCallbackHistory] =
+      test.repeatMockWithHistory(
+        2,
+        (_valueX: string, _valueY: string) => {},
+      )
+    await compute.effect(effectCallback, x2, y2)
+    test.assertDeepEquals(x2CallbackHistory, [['x']])
+    test.assertDeepEquals(y2CallbackHistory, [['y']])
+    test.assertDeepEquals(effectCallbackHistory, [['x/x', 'y?y']])
+
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'a')
+    })
+    test.assertDeepEquals(x2CallbackHistory, [['x'], ['a']])
+    test.assertDeepEquals(y2CallbackHistory, [['y']])
+    test.assertDeepEquals(effectCallbackHistory, [
+      ['x/x', 'y?y'],
+      ['a/a', 'y?y'],
+    ])
+    test.assertEquals(await compute.value(x), 'a')
+    test.assertEquals(await compute.value(y), 'y')
+  },
+
+  async ['effect, unsubscribe'](): Promise<void> {
+    const ctx = { compute: new compute.Compute() }
+
+    const x = compute.state('x')
+    const [x2Callback, x2CallbackHistory] = test.repeatMockWithHistory(
+      3,
+      (value: string) => `${value}2`,
+    )
+    const x2 = compute.map(x2Callback, x)
+    const [x3Callback, x3CallbackHistory] = test.repeatMockWithHistory(
+      2,
+      (value: string) => `${value}3`,
+    )
+    const x3 = compute.map(x3Callback, x)
+    const x4Callback = test.repeatMock(0, (value: string) => `${value}4`)
+    compute.map(x4Callback, x)
+
+    const [effect1Callback, effect1CallbackHistory] =
+      test.repeatMockWithHistory(3, (_valueX2: string) => {})
+    await compute.effect(effect1Callback, x2)
+    test.assertDeepEquals(x2CallbackHistory, [['x']])
+    test.assertDeepEquals(x3CallbackHistory, [])
+    test.assertDeepEquals(effect1CallbackHistory, [['x2']])
+
+    const [effect2Callback, effect2CallbackHistory] =
+      test.repeatMockWithHistory(
+        2,
+        (_valueX2: string, _valueX3: string) => {},
+      )
+    const effect2 = await compute.effect(effect2Callback, x2, x3)
+    test.assertDeepEquals(x2CallbackHistory, [['x']])
+    test.assertDeepEquals(x3CallbackHistory, [['x']])
+    test.assertDeepEquals(effect2CallbackHistory, [['x2', 'x3']])
+
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'a')
+    })
+    test.assertDeepEquals(x2CallbackHistory, [['x'], ['a']])
+    test.assertDeepEquals(x3CallbackHistory, [['x'], ['a']])
+    test.assertDeepEquals(effect1CallbackHistory, [['x2'], ['a2']])
+    test.assertDeepEquals(effect2CallbackHistory, [
+      ['x2', 'x3'],
+      ['a2', 'a3'],
+    ])
+    test.assertEquals(await compute.value(x), 'a')
+
+    compute.unsubscribe(effect2)
+    await compute.txn(ctx, async () => {
+      await compute.set(ctx, x, 'b')
+    })
+    test.assertDeepEquals(x2CallbackHistory, [['x'], ['a'], ['b']])
+    test.assertDeepEquals(x3CallbackHistory, [['x'], ['a']])
+    test.assertDeepEquals(effect1CallbackHistory, [['x2'], ['a2'], ['b2']])
+    test.assertDeepEquals(effect2CallbackHistory, [
+      ['x2', 'x3'],
+      ['a2', 'a3'],
+    ])
+    test.assertEquals(await compute.value(x), 'b')
+  },
+}

--- a/lib-compute/index.ts
+++ b/lib-compute/index.ts
@@ -1,0 +1,539 @@
+export interface Context {
+  readonly compute: Compute
+}
+
+export class Compute {
+  private mutableEpoch: Epoch = new Epoch(0)
+  private readonly mutableTransactions: [
+    commitImpl: CommitImpl<unknown>,
+    newValue: unknown,
+  ][][] = []
+
+  get inProgressEpoch(): Epoch | null {
+    return this.mutableEpoch.inProgress ? this.mutableEpoch : null
+  }
+
+  async beginTransaction(): Promise<void> {
+    if (!this.mutableTransactions.length) {
+      await this.mutableEpoch.wait()
+    }
+    this.mutableTransactions.push([])
+  }
+
+  async commitTransaction(): Promise<void> {
+    if (!this.mutableTransactions.length) {
+      throw new Error('Cannot commit without transaction')
+    }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- already checked
+    const transaction = this.mutableTransactions.pop()!
+    if (!this.mutableTransactions.length) {
+      this.mutableEpoch = new Epoch(this.mutableEpoch.id + 1)
+      for (const [commitImpl, newValue] of transaction) {
+        commitImpl.commit(this.mutableEpoch, newValue)
+      }
+      for (const [commitImpl] of transaction) {
+        await commitImpl.update(this.mutableEpoch)
+      }
+      await this.mutableEpoch.wait()
+    } else {
+      const mutableParentTransaction =
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- already checked
+        this.mutableTransactions[this.mutableTransactions.length - 1]!
+      mutableParentTransaction.push(...transaction)
+    }
+  }
+
+  rollbackTransaction(): void {
+    if (!this.mutableTransactions.length) {
+      throw new Error('Cannot rollback without transaction')
+    }
+    this.mutableTransactions.pop()
+  }
+
+  setState(mutableNodeImpl: CommitImpl<unknown>, newValue: unknown): void {
+    if (!this.mutableTransactions.length) {
+      throw new Error('Cannot set state without transaction')
+    }
+    const mutableTransaction =
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- already checked
+      this.mutableTransactions[this.mutableTransactions.length - 1]!
+    mutableTransaction.push([mutableNodeImpl, newValue])
+  }
+}
+
+class Epoch {
+  readonly mutablePromises = new Set<Promise<unknown>>()
+
+  constructor(readonly id: number) {}
+
+  get inProgress(): boolean {
+    return !!this.mutablePromises.size
+  }
+
+  add(promise: Promise<unknown>): void {
+    this.mutablePromises.add(promise)
+  }
+
+  async wait(): Promise<void> {
+    while (this.mutablePromises.size) {
+      const promise = this.mutablePromises.keys().next()
+        .value as Promise<unknown>
+      await promise
+      this.mutablePromises.delete(promise)
+    }
+  }
+}
+
+const nodeImpl = Symbol('nodeImpl')
+
+type Node<Value, Mutable extends boolean, State extends boolean> = {
+  readonly [Key in keyof Value]: Node<Value[Key], Mutable, State>
+} & {
+  readonly [nodeImpl]: NodeImpl<Value, Mutable, State>
+}
+
+type NodeImpl<Value, Mutable extends boolean, State extends boolean> =
+  Mutable extends false ? ComputationImpl<Value>
+  : State extends false ? MutationImpl<Value>
+  : CommitImpl<Value>
+
+interface ComputationImpl<Value> {
+  readonly links: Links
+  update(newEpoch: Epoch): Promise<Value>
+}
+
+interface MutationImpl<Value> extends ComputationImpl<Value> {
+  set(ctx: Context, newValue: Value): Promise<void>
+}
+
+interface CommitImpl<Value> extends MutationImpl<Value> {
+  commit(newEpoch: Epoch, newValue: Value): void
+}
+
+export type Computation<Value> = Node<Value, boolean, boolean>
+export type Mutation<Value> = Node<Value, true, boolean>
+
+export type ComputationTuple<Tuple extends readonly unknown[]> = {
+  readonly length: Tuple['length']
+} & { [I in keyof Tuple]: Computation<Tuple[I]> }
+
+class Links {
+  private readonly mutableSubs: WeakRef<Computation<unknown>>[] = []
+  private readonly mutableSubscribeCount: [number] = [0]
+
+  constructor(readonly deps: readonly Computation<unknown>[]) {}
+
+  static subscribe(sub: Computation<unknown>): void {
+    const subLinks = sub[nodeImpl].links
+    subLinks.mutableSubscribeCount[0]++
+    if (subLinks.mutableSubscribeCount[0] === 1) {
+      for (const dep of subLinks.deps) {
+        const depLinks = dep[nodeImpl].links
+        depLinks.mutableSubs.push(new WeakRef(sub))
+        Links.subscribe(dep)
+      }
+    }
+  }
+
+  static unsubscribe(sub: Computation<unknown>): void {
+    const subLinks = sub[nodeImpl].links
+    subLinks.mutableSubscribeCount[0]--
+    if (subLinks.mutableSubscribeCount[0] === 0) {
+      for (const dep of subLinks.deps) {
+        const depLinks = dep[nodeImpl].links
+        for (let i = 0; i < depLinks.mutableSubs.length; i++) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- already checked
+          const otherSub = dep[nodeImpl].links.mutableSubs[i]!
+          if (otherSub.deref() === sub) {
+            depLinks.mutableSubs.splice(i, 1)
+            Links.unsubscribe(dep)
+            break
+          }
+        }
+      }
+    }
+  }
+
+  updateSubs(newEpoch: Epoch): void {
+    let i = 0
+    while (i < this.mutableSubs.length) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- already checked
+      const sub = this.mutableSubs[i]!.deref()
+      if (!sub) {
+        this.mutableSubs.splice(i, 1)
+      } else {
+        newEpoch.add(sub[nodeImpl].update(newEpoch))
+        i++
+      }
+    }
+  }
+}
+
+class NodeProxy
+  implements ProxyHandler<NodeImpl<unknown, boolean, boolean>>
+{
+  private static mutableInstance: NodeProxy | null = null
+
+  private constructor() {}
+
+  static build<Value, Mutable extends boolean, State extends boolean>(
+    mutableImpl: NodeImpl<Value, Mutable, State>,
+  ): Node<Value, Mutable, State> {
+    if (!NodeProxy.mutableInstance) {
+      NodeProxy.mutableInstance = new NodeProxy()
+    }
+    return new Proxy(
+      mutableImpl,
+      NodeProxy.mutableInstance as ProxyHandler<object>,
+    ) as unknown as Node<Value, Mutable, State>
+  }
+
+  get(
+    mutableTarget: NodeImpl<unknown, boolean, boolean>,
+    property: number | string | symbol,
+    receiver: unknown,
+  ): unknown {
+    if (property === nodeImpl) {
+      return mutableTarget
+    } else if ('set' in mutableTarget) {
+      return NodeProxy.build<unknown, true, false>(
+        new DerivedImpl(
+          new MapImpl(
+            async (depValues) => {
+              return Promise.resolve(
+                (depValues as [Record<string | symbol, unknown>])[0][
+                  property
+                ],
+              )
+            },
+            new Links([receiver as Mutation<unknown>]),
+          ),
+          async (ctx, newValue, depValues) => {
+            if (Array.isArray(depValues[0])) {
+              await set(ctx, receiver as Mutation<unknown>, [
+                ...(depValues[0] as unknown[]).slice(
+                  0,
+                  property as number,
+                ),
+                newValue,
+                ...(depValues[0] as unknown[]).slice(
+                  (property as number) + 1,
+                ),
+              ])
+            } else {
+              await set(ctx, receiver as Mutation<unknown>, {
+                ...(depValues[0] as Record<string | symbol, unknown>),
+                [property]: newValue,
+              })
+            }
+          },
+        ),
+      )
+    } else {
+      return NodeProxy.build<unknown, false, false>(
+        new MapImpl(
+          async (depValues) => {
+            return Promise.resolve(
+              (depValues as [Record<string | symbol, unknown>])[0][
+                property
+              ],
+            )
+          },
+          new Links([receiver as Computation<unknown>]),
+        ),
+      )
+    }
+  }
+}
+
+export async function set<Value>(
+  ctx: Context,
+  mutation: Mutation<Value>,
+  newValue: Value,
+): Promise<void> {
+  await mutation[nodeImpl].set(ctx, newValue)
+}
+
+export async function txn<T>(
+  ctx: Context,
+  callback: () => Promise<T>,
+): Promise<T> {
+  let result: T
+  try {
+    await ctx.compute.beginTransaction()
+    result = await callback()
+  } catch (error) {
+    ctx.compute.rollbackTransaction()
+    throw error
+  }
+  await ctx.compute.commitTransaction()
+  return result
+}
+
+export async function value<Value>(
+  computation: Computation<Value>,
+): Promise<Value> {
+  const epoch = new Epoch(0)
+  const result = computation[nodeImpl].update(epoch)
+  await epoch.wait()
+  return result
+}
+
+export function handler<Result, EventArg, OtherArgs extends unknown[]>(
+  callback: (
+    event: EventArg,
+    ...otherArgs: OtherArgs
+  ) => Promise<Result> | Result,
+  ...computations: ComputationTuple<OtherArgs>
+): (event: EventArg) => Promise<Result> {
+  return async (event) => {
+    const computationValues = (await Promise.all(
+      computations.map(value),
+    )) as OtherArgs
+    return callback(event, ...computationValues)
+  }
+}
+
+export function pure<Value>(value: Value): Computation<Value> {
+  return NodeProxy.build(new PureImpl(value))
+}
+
+export function unsubscribe(computation: Computation<unknown>): void {
+  Links.unsubscribe(computation)
+}
+
+class PureImpl<Value> implements ComputationImpl<Value> {
+  readonly links: Links = new Links([])
+
+  constructor(private readonly value: Value) {}
+
+  async update(_newEpoch: Epoch): Promise<Value> {
+    return Promise.resolve(this.value)
+  }
+}
+
+export function state<Value>(init: Value): Mutation<Value> {
+  return NodeProxy.build<Value, true, true>(new StateImpl(init))
+}
+
+class StateImpl<Value> implements CommitImpl<Value> {
+  readonly links: Links = new Links([])
+
+  private mutableEpoch: Epoch = new Epoch(0)
+  private mutableUpdated: boolean = true
+  private mutableValue: Value
+
+  constructor(value: Value) {
+    this.mutableValue = value
+  }
+
+  commit(newEpoch: Epoch, newValue: Value): void {
+    if (this.mutableValue !== newValue) {
+      this.mutableEpoch = newEpoch
+      this.mutableValue = newValue
+      this.mutableUpdated = false
+    }
+  }
+
+  async set(ctx: Context, newValue: Value): Promise<void> {
+    ctx.compute.setState(this, newValue)
+    return Promise.resolve()
+  }
+
+  async update(newEpoch: Epoch): Promise<Value> {
+    if (newEpoch.id >= this.mutableEpoch.id && !this.mutableUpdated) {
+      this.links.updateSubs(newEpoch)
+      this.mutableUpdated = true
+    }
+    return Promise.resolve(this.mutableValue)
+  }
+}
+
+export function map<Args extends readonly unknown[], Result>(
+  transform: (...args: Args) => Promise<Result> | Result,
+  ...computations: ComputationTuple<Args>
+): Computation<Result> {
+  return NodeProxy.build(
+    new MapImpl(
+      async (args) => transform(...(args as Args)),
+      new Links(computations),
+    ),
+  )
+}
+
+type MapImplIteration<Value> = readonly [
+  epoch: Epoch,
+  depValues: readonly unknown[],
+  value: Value,
+]
+
+class MapImpl<Value> implements ComputationImpl<Value> {
+  mutableUpdateIteration: Promise<MapImplIteration<Value>> | null = null
+
+  constructor(
+    private readonly updateImpl: (
+      depValues: readonly unknown[],
+    ) => Promise<Value>,
+    readonly links: Links,
+  ) {}
+
+  async update(newEpoch: Epoch): Promise<Value> {
+    let previousIteration: MapImplIteration<Value> | null
+    while (true) {
+      const originalIterationPromise = this.mutableUpdateIteration
+      const iteration = await this.mutableUpdateIteration
+      if (this.mutableUpdateIteration === originalIterationPromise) {
+        previousIteration = iteration
+        break
+      }
+    }
+    if (previousIteration && previousIteration[0].id >= newEpoch.id) {
+      return previousIteration[2]
+    } else {
+      this.mutableUpdateIteration = this.runNewIteration(
+        newEpoch,
+        previousIteration,
+      )
+      const newIteration = await this.mutableUpdateIteration
+      return newIteration[2]
+    }
+  }
+
+  private async runNewIteration(
+    newEpoch: Epoch,
+    previousIteration: MapImplIteration<Value> | null,
+  ): Promise<MapImplIteration<Value>> {
+    const depValues = await Promise.all(
+      this.links.deps.map(async (dep) => dep[nodeImpl].update(newEpoch)),
+    )
+    let value: Value
+    if (
+      !previousIteration ||
+      depValues.some((depValue, i) => depValue !== previousIteration[1][i])
+    ) {
+      value = await this.updateImpl(depValues)
+      if (previousIteration && value !== previousIteration[2]) {
+        this.links.updateSubs(newEpoch)
+      }
+    } else {
+      value = previousIteration[2]
+    }
+    return [newEpoch, depValues, value]
+  }
+}
+
+export function derived<Result, Args extends readonly unknown[]>(
+  get: (...args: Args) => Promise<Result> | Result,
+  set: (newValue: Result, ...args: Args) => Promise<void>,
+  ...computations: ComputationTuple<Args>
+): Mutation<Result> {
+  return NodeProxy.build<Result, true, false>(
+    new DerivedImpl(
+      new MapImpl(async (depValues) => {
+        return get(...(depValues as Args))
+      }, new Links(computations)),
+      async (_ctx, newValue, depValues) => {
+        await set(newValue, ...(depValues as Args))
+      },
+    ),
+  )
+}
+
+class DerivedImpl<Value> implements ComputationImpl<Value> {
+  constructor(
+    private readonly mapImpl: ComputationImpl<Value>,
+    private readonly setImpl: (
+      ctx: Context,
+      newValue: Value,
+      depValues: readonly unknown[],
+    ) => Promise<void>,
+  ) {}
+
+  get links(): Links {
+    return this.mapImpl.links
+  }
+
+  async set(ctx: Context, newValue: Value): Promise<void> {
+    const epoch = ctx.compute.inProgressEpoch
+    const computationValues =
+      epoch ?
+        await Promise.all(
+          this.links.deps.map(async (dep) => dep[nodeImpl].update(epoch)),
+        )
+      : await Promise.all(this.links.deps.map(value))
+    await this.setImpl(ctx, newValue, computationValues)
+  }
+
+  async update(newEpoch: Epoch): Promise<Value> {
+    return this.mapImpl.update(newEpoch)
+  }
+}
+
+export async function effect<Args extends unknown[]>(
+  callback: (...args: Args) => Promise<void> | void,
+  ...computations: ComputationTuple<Args>
+): Promise<Computation<void>> {
+  const node = NodeProxy.build(
+    new EffectImpl(async (depValues) => {
+      await callback(...(depValues as Args))
+    }, new Links(computations)),
+  )
+  const epoch = new Epoch(0)
+  await node[nodeImpl].update(epoch)
+  await epoch.wait()
+  Links.subscribe(node)
+  return node
+}
+
+type EffectImplIteration = readonly [
+  epoch: Epoch,
+  depValues: readonly unknown[],
+]
+
+class EffectImpl implements ComputationImpl<void> {
+  mutableUpdateIteration: Promise<EffectImplIteration> | null = null
+
+  constructor(
+    private readonly updateImpl: (
+      depValues: readonly unknown[],
+    ) => Promise<void>,
+    readonly links: Links,
+  ) {}
+
+  async update(newEpoch: Epoch): Promise<void> {
+    let previousIteration: EffectImplIteration | null
+    while (true) {
+      const originalIterationPromise = this.mutableUpdateIteration
+      const iteration = await this.mutableUpdateIteration
+      if (this.mutableUpdateIteration === originalIterationPromise) {
+        previousIteration = iteration
+        break
+      }
+    }
+    if (previousIteration && previousIteration[0].id >= newEpoch.id) {
+      // Already done
+    } else {
+      this.mutableUpdateIteration = this.runNewIteration(
+        newEpoch,
+        previousIteration,
+      )
+      await this.mutableUpdateIteration
+    }
+  }
+
+  private async runNewIteration(
+    newEpoch: Epoch,
+    previousIteration: EffectImplIteration | null,
+  ): Promise<EffectImplIteration> {
+    const depValues = await Promise.all(
+      this.links.deps.map(async (dep) => dep[nodeImpl].update(newEpoch)),
+    )
+    if (
+      !previousIteration ||
+      depValues.some((depValue, i) => depValue !== previousIteration[1][i])
+    ) {
+      await this.updateImpl(depValues)
+    }
+    return [newEpoch, depValues]
+  }
+}

--- a/lib-compute/package.json
+++ b/lib-compute/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@intertwine/lib-compute",
+  "type": "module",
+  "dependencies": {
+    "@intertwine/dev-prettier": "workspace:*",
+    "@intertwine/dev-tsconfig": "workspace:*",
+    "@intertwine/lib-collection": "workspace:*",
+    "@intertwine/lib-test": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2"
+  },
+  "prettier": "@intertwine/dev-prettier/index.json"
+}

--- a/lib-compute/tsconfig.json
+++ b/lib-compute/tsconfig.json
@@ -8,14 +8,7 @@
   "extends": "@intertwine/dev-tsconfig/tsconfig.json",
   "include": ["./**/*.ts", "./**/*.js", "./**/*.cjs"],
   "references": [
-    { "path": "../lib-compute" },
-    { "path": "../lib-error" },
-    { "path": "../lib-hex-ts" },
-    { "path": "../lib-payload" },
-    { "path": "../lib-random" },
-    { "path": "../lib-style" },
-    { "path": "../lib-test" },
-    { "path": "../lib-time" },
-    { "path": "../svc-auth-guest-view" }
+    { "path": "../lib-collection" },
+    { "path": "../lib-test" }
   ]
 }

--- a/lib-concurrency/eventSemaphore.ts
+++ b/lib-concurrency/eventSemaphore.ts
@@ -3,9 +3,7 @@ export class EventSemaphore {
   private mutableResolve!: () => void
   private mutableResolved: boolean = true
 
-  private constructor() {
-    // Private
-  }
+  private constructor() {}
 
   static build(): Readonly<EventSemaphore> {
     const eventSemaphore = new EventSemaphore()

--- a/lib-error/index.test.ts
+++ b/lib-error/index.test.ts
@@ -1,4 +1,5 @@
 import * as error from '@/index.ts'
+import type * as random from '@intertwine/lib-random'
 import * as test from '@intertwine/lib-test'
 import * as time from '@intertwine/lib-time'
 
@@ -16,7 +17,7 @@ export const tests = {
       ...baseContext,
       random: {
         ...baseContext.random,
-        number: test.mock([]),
+        number: test.mock<random.Random['number']>([]),
       },
     }
     const expectedResult = {}
@@ -42,13 +43,13 @@ export const tests = {
       ...baseContext,
       random: {
         ...baseContext.random,
-        number: test.mock([() => 0.5]),
+        number: test.mock<random.Random['number']>([() => 0.5]),
       },
     }
     const expectedResult = new Error('TEST')
-    const [onError, onErrorHistory] = test.mockWithHistory([
-      () => undefined,
-    ])
+    const [onError, onErrorHistory] = test.mockWithHistory<
+      error.RetryConfig['onError']
+    >([() => undefined])
     const actualResult = test.sync(
       error.retry(ctx, async () => Promise.reject(expectedResult), {
         maxAttempts: 2,
@@ -73,14 +74,13 @@ export const tests = {
       ...baseContext,
       random: {
         ...baseContext.random,
-        number: test.mock([() => 0.8, () => 0.8]),
+        number: test.mock<random.Random['number']>([() => 0.8, () => 0.8]),
       },
     }
     const expectedResult = new Error('TEST')
-    const [onError, onErrorHistory] = test.mockWithHistory([
-      () => undefined,
-      () => undefined,
-    ])
+    const [onError, onErrorHistory] = test.mockWithHistory<
+      error.RetryConfig['onError']
+    >([() => undefined, () => undefined])
     const actualResult = test.sync(
       error.retry(ctx, async () => Promise.reject(expectedResult), {
         maxAttempts: 3,
@@ -111,7 +111,7 @@ export const tests = {
       ...baseContext,
       random: {
         ...baseContext.random,
-        number: test.mock([() => 0]),
+        number: test.mock<random.Random['number']>([() => 0]),
       },
     }
     const expectedResult = new Error('TEST')
@@ -144,14 +144,17 @@ export const tests = {
       ...baseContext,
       random: {
         ...baseContext.random,
-        number: test.mock([() => 0.6, () => 0.6, () => 0]),
+        number: test.mock<random.Random['number']>([
+          () => 0.6,
+          () => 0.6,
+          () => 0,
+        ]),
       },
     }
     const expectedResult = new Error('TEST')
-    const [onError, onErrorHistory] = test.mockWithHistory([
-      () => undefined,
-      () => undefined,
-    ])
+    const [onError, onErrorHistory] = test.mockWithHistory<
+      error.RetryConfig['onError']
+    >([() => undefined, () => undefined])
     const actualResult = test.sync(
       error.retry(ctx, async () => Promise.reject(expectedResult), {
         maxAttempts: 10,
@@ -183,7 +186,7 @@ export const tests = {
       ...baseContext,
       random: {
         ...baseContext.random,
-        number: test.mock([() => 0.8, () => 0.8]),
+        number: test.mock<random.Random['number']>([() => 0.8, () => 0.8]),
       },
     }
     const expectedResult = {}
@@ -193,10 +196,9 @@ export const tests = {
       async () => Promise.reject(expectedError),
       async () => Promise.resolve(expectedResult),
     ])
-    const [onError, onErrorHistory] = test.mockWithHistory([
-      () => undefined,
-      () => undefined,
-    ])
+    const [onError, onErrorHistory] = test.mockWithHistory<
+      error.RetryConfig['onError']
+    >([() => undefined, () => undefined])
     const actualResult = test.sync(
       error.retry(ctx, callback, {
         maxAttempts: 3,

--- a/lib-stream/server.ts
+++ b/lib-stream/server.ts
@@ -19,9 +19,7 @@ export class Server {
     streamSource.Source<streamConnection.ConnectionRequest>
   >(() => streamSource.Source.build())
 
-  private constructor() {
-    // Private
-  }
+  private constructor() {}
 
   static init(ctx: time.Context): Server {
     const server = new Server()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       '@intertwine/dev-tsconfig':
         specifier: workspace:*
         version: link:../dev-tsconfig
+      '@intertwine/lib-compute':
+        specifier: workspace:*
+        version: link:../lib-compute
       '@intertwine/lib-error':
         specifier: workspace:*
         version: link:../lib-error
@@ -273,6 +276,25 @@ importers:
       '@intertwine/dev-tsconfig':
         specifier: workspace:*
         version: link:../dev-tsconfig
+    devDependencies:
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
+  lib-compute:
+    dependencies:
+      '@intertwine/dev-prettier':
+        specifier: workspace:*
+        version: link:../dev-prettier
+      '@intertwine/dev-tsconfig':
+        specifier: workspace:*
+        version: link:../dev-tsconfig
+      '@intertwine/lib-collection':
+        specifier: workspace:*
+        version: link:../lib-collection
+      '@intertwine/lib-test':
+        specifier: workspace:*
+        version: link:../lib-test
     devDependencies:
       typescript:
         specifier: 5.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
   - dev-prettier
   - dev-tsconfig
   - lib-collection
+  - lib-compute
   - lib-concurrency
   - lib-error
   - lib-hex-ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "./dev-node-suppress" },
     { "path": "./dev-pnpm-test" },
     { "path": "./lib-collection" },
+    { "path": "./lib-compute" },
     { "path": "./lib-concurrency" },
     { "path": "./lib-error" },
     { "path": "./lib-hex-ts" },


### PR DESCRIPTION
For #83

- [x] Computation
- [x] State
- [x] Map
- [x] Epoch
- [x] Tests
  - [x] Transaction rollback
  - [x] Map/derive callback history
  - [x] Multiple arguments
  - [x] Two root states
- [x] Deps class
  - [x] Use list of weak references for reverse deps
  - [x] Fan out cleans up the list, adds to epoch
  - [x] Only add reverse deps after first effect update